### PR TITLE
feat: Allow napari-copick to shrink beyond its current minimum width.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ dependencies = [
     "trimesh",
     "fsspec",
     "pydantic>=2",
-    "copick>=1.23.1",
+    "copick>=1.26.1",
     "napari-ome-zarr",
     "click",
-    "copick-shared-ui>=0.5.0",
+    "copick-shared-ui>=0.7.0",
     "napari",
 ]
 authors = [

--- a/src/napari_copick/gallery_widget.py
+++ b/src/napari_copick/gallery_widget.py
@@ -61,7 +61,8 @@ class NapariCopickGalleryWidget(QWidget):
         header_layout = QHBoxLayout()
 
         # Back to tree button
-        self.back_button = QPushButton("← Back to Tree View")
+        self.back_button = QPushButton("← Tree")
+        self.back_button.setToolTip("Back to the tree view")
         self.back_button.clicked.connect(self._on_back_clicked)
         header_layout.addWidget(self.back_button)
 

--- a/src/napari_copick/widget.py
+++ b/src/napari_copick/widget.py
@@ -100,19 +100,21 @@ class CopickPlugin(QWidget):
         load_options_layout = QHBoxLayout()
 
         # Config file button
-        self.load_config_button = QPushButton("Load Config File")
+        self.load_config_button = QPushButton("Load Config")
+        self.load_config_button.setToolTip("Load a copick configuration file")
         self.load_config_button.clicked.connect(self.config_manager.open_file_dialog)
         load_options_layout.addWidget(self.load_config_button)
 
         # Dataset IDs button
-        self.load_dataset_button = QPushButton("Load from Dataset IDs")
+        self.load_dataset_button = QPushButton("Dataset IDs")
+        self.load_dataset_button.setToolTip("Load from CZ cryoET Data Portal dataset IDs")
         self.load_dataset_button.clicked.connect(self.config_manager.open_dataset_dialog)
         load_options_layout.addWidget(self.load_dataset_button)
 
         layout.addLayout(load_options_layout)
 
         # Edit Object Types button
-        self.edit_objects_button = QPushButton("✏️ Edit Object Types")
+        self.edit_objects_button = QPushButton("✏️ Edit Objects")
         self.edit_objects_button.clicked.connect(self.config_manager.open_edit_objects_dialog)
         self.edit_objects_button.setEnabled(False)  # Disabled until config is loaded
         self.edit_objects_button.setToolTip("Edit or add new object types in the configuration")
@@ -120,6 +122,10 @@ class CopickPlugin(QWidget):
 
         # Create tab widget for tree and gallery views
         self.tab_widget = QTabWidget()
+        # Let the tab bar elide/scroll instead of pinning a wide minimum width
+        # on small screens.
+        self.tab_widget.tabBar().setElideMode(Qt.ElideRight)
+        self.tab_widget.setUsesScrollButtons(True)
 
         # Tree view tab
         tree_tab = QWidget()
@@ -148,7 +154,7 @@ class CopickPlugin(QWidget):
         save_buttons_layout = QHBoxLayout()
 
         # Save segmentation button
-        self.save_segmentation_button = QPushButton("💾 Save Segmentation")
+        self.save_segmentation_button = QPushButton("💾 Save Seg")
         self.save_segmentation_button.clicked.connect(self.save_manager.open_save_segmentation_dialog)
         self.save_segmentation_button.setEnabled(False)  # Disabled until config is loaded
         self.save_segmentation_button.setToolTip("Save a segmentation layer to copick")
@@ -213,11 +219,17 @@ class CopickPlugin(QWidget):
 
         # Resolution level selector
         resolution_layout = QHBoxLayout()
-        resolution_label = QLabel("Image Resolution:")
+        resolution_label = QLabel("Resolution:")
         self.resolution_combo = QComboBox()
-        self.resolution_combo.addItems(
-            ["0 - Highest (Full Resolution)", "1 - Medium (Binned by 2)", "2 - Lowest (Binned by 4)"],
-        )
+        # Short labels keep the collapsed combo narrow; full descriptions are in
+        # per-item tooltips. Selection is read by index, so text is display-only.
+        self.resolution_combo.addItems(["0 - Full", "1 - Bin 2", "2 - Bin 4"])
+        self.resolution_combo.setItemData(0, "0 - Highest (Full Resolution)", Qt.ToolTipRole)
+        self.resolution_combo.setItemData(1, "1 - Medium (Binned by 2)", Qt.ToolTipRole)
+        self.resolution_combo.setItemData(2, "2 - Lowest (Binned by 4)", Qt.ToolTipRole)
+        self.resolution_combo.setToolTip("Resolution / binning level used to load tomograms")
+        self.resolution_combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        self.resolution_combo.setMinimumContentsLength(6)
         self.resolution_combo.setCurrentIndex(1)  # Default to medium resolution
         resolution_layout.addWidget(resolution_label)
         resolution_layout.addWidget(self.resolution_combo)

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,15 @@ required-markers = [
 ]
 
 [[package]]
+name = "absl-py"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/4f/d79676ab82f2e42fc3611618139f13a9c4c31d0cff4b486982047679a802/absl_py-2.5.0.tar.gz", hash = "sha256:0c996f25c0490700fadabe6351630f6111534fa0ae252cc6d2014ea3b141135f", size = 118119, upload-time = "2026-07-03T10:57:48.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl", hash = "sha256:0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba", size = 137410, upload-time = "2026-07-03T10:57:46.735Z" },
+]
+
+[[package]]
 name = "aiobotocore"
 version = "2.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -599,15 +608,17 @@ wheels = [
 
 [[package]]
 name = "copick"
-version = "1.23.1"
+version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "click" },
     { name = "cryoet-data-portal" },
     { name = "distinctipy" },
     { name = "dynamotable" },
     { name = "emfile" },
     { name = "fsspec" },
+    { name = "mlcroissant" },
     { name = "mrcfile" },
     { name = "numcodecs", version = "0.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numcodecs", version = "0.15.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -631,9 +642,9 @@ dependencies = [
     { name = "zarr", version = "2.18.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "zarr", version = "2.18.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/23/14b0f3b12f3b34ca53448621fa1eaf6ff508b93338865a82cc329d8183d4/copick-1.23.1.tar.gz", hash = "sha256:74098ecfe2013eea94380dbb2fd912a9d4f31273b8643f712f3a7067937ab331", size = 9357378, upload-time = "2026-04-01T00:32:18.955Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3c/a4abaee6ddfe2b5a787811383b1df5f1f5dfb7dbe34c18463565f555d671/copick-1.26.1.tar.gz", hash = "sha256:5ddea60511ff142fdfcc6d2b2c773184a61c8d69e3243ff0df3ee2e400392de3", size = 47784270, upload-time = "2026-07-08T00:05:41.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/73/2a23cc60fa90af74c7cd4cefc986bcf2a3a56690f49cc89ad31e2764257d/copick-1.23.1-py3-none-any.whl", hash = "sha256:c45081b0f49d411e4f32a415b988b4cf46cfb446bb70810bc8fb64c89627be26", size = 156689, upload-time = "2026-04-01T00:32:17.517Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5b/1e6f8eb6c653c99bf9a12560e7fcc3621b8b8ee7cc04279255595103f7ce/copick-1.26.1-py3-none-any.whl", hash = "sha256:f770ccd0aac4ff37dfd2aa3992f09ea30e2a713a6c0143041607d738f7324288", size = 224038, upload-time = "2026-07-08T00:05:38.115Z" },
 ]
 
 [package.optional-dependencies]
@@ -643,7 +654,7 @@ all = [
 
 [[package]]
 name = "copick-shared-ui"
-version = "0.5.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "copick", extra = ["all"] },
@@ -655,9 +666,9 @@ dependencies = [
     { name = "zarr", version = "2.18.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "zarr", version = "2.18.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/4d/417172a962b742f74f08184ec78fce1cf01310c4d1733e46c906f738514d/copick_shared_ui-0.5.0.tar.gz", hash = "sha256:540f2eaa22447ef9cc70b2632010925e20ecddcb278193b4ff55948a942a34b3", size = 64221, upload-time = "2026-04-01T00:35:31.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/6b/354a0cf27b1b93546240e43f75bce6cc68afea54d46db44fdac215b878a3/copick_shared_ui-0.7.0.tar.gz", hash = "sha256:8fdacc50de22cbabf9a4cc51874f9842dbdb505aabc404b4b2b78a9cbc825858", size = 318358, upload-time = "2026-07-20T21:26:07.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/2a/b50e606184890cd94c1498452a9da06596c2e9313b646b83a422f81cb5cc/copick_shared_ui-0.5.0-py3-none-any.whl", hash = "sha256:73b922731620480972044e2e6fc0280694c1230c78f51a247d43a2ed0f31ff75", size = 82199, upload-time = "2026-04-01T00:35:29.579Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/fab6abc85aedf90b384178025caa8d1b795796120002f89a7e33aa7aa3c1/copick_shared_ui-0.7.0-py3-none-any.whl", hash = "sha256:8a2fd2acb8df4522dc3931d85c7df9994a9a37030ad299d8bc70b9fd89b5f50a", size = 85633, upload-time = "2026-07-20T21:26:06.345Z" },
 ]
 
 [[package]]
@@ -959,6 +970,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5c/11/3647ed3d691400e669fa799f561ae850204179f809185652c5e7aae8dfe3/emfile-0.3.0.tar.gz", hash = "sha256:d7e9114aac5e2a29db9d77ab669659499c2f8c38ca13a5ff468c39ec89181a9b", size = 4081, upload-time = "2021-11-25T13:38:43.198Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/51/482938baea53321ad0482544e9147905e96d9e7f29ab368d3a9c59b7e8f9/emfile-0.3.0-py3-none-any.whl", hash = "sha256:cda7eb08b74cacd9ce5b38d1e52abbf08092d7352ed5abe8b2ba50c54412eedf", size = 4787, upload-time = "2021-11-25T13:38:41.962Z" },
+]
+
+[[package]]
+name = "etils"
+version = "1.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version > '3.10' and python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version > '3.10' and python_full_version < '3.11' and sys_platform != 'win32')",
+    "python_full_version > '3.10' and python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "(python_full_version <= '3.10' and platform_machine != 'x86_64') or (python_full_version <= '3.10' and sys_platform != 'win32')",
+    "python_full_version <= '3.10' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/a0/522bbff0f3cdd37968f90dd7f26c7aa801ed87f5ba335f156de7f2b88a48/etils-1.13.0.tar.gz", hash = "sha256:a5b60c71f95bcd2d43d4e9fb3dc3879120c1f60472bb5ce19f7a860b1d44f607", size = 106368, upload-time = "2025-07-15T10:29:10.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/98/87b5946356095738cb90a6df7b35ff69ac5750f6e783d5fbcc5cb3b6cbd7/etils-1.13.0-py3-none-any.whl", hash = "sha256:d9cd4f40fbe77ad6613b7348a18132cc511237b6c076dbb89105c0b520a4c6bb", size = 170603, upload-time = "2025-07-15T10:29:09.076Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec", marker = "python_full_version < '3.11'" },
+    { name = "importlib-resources", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
+]
+
+[[package]]
+name = "etils"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'win32')",
+    "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/ce/6e067242fde898841922ac6fc82b0bb2fe35c38e995880bdffdfbe30182a/etils-1.14.0.tar.gz", hash = "sha256:8136e7f4c4173cd0af0ca5481c4475152f0b8686192951eefa60ee8711e1ede4", size = 108127, upload-time = "2026-03-04T17:41:36.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/3d/589663aeeacd59bb2f3e8596bfd3e81cf0fb18d70bb433199041f469771b/etils-1.14.0-py3-none-any.whl", hash = "sha256:b5df7341f54dbe1405a4450b2741207b4a8c279780402b45f87202b94dfc52b4", size = 172934, upload-time = "2026-03-04T17:41:35.01Z" },
+]
+
+[package.optional-dependencies]
+epath = [
+    { name = "fsspec", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.11'" },
+    { name = "zipp", marker = "python_full_version >= '3.11'" },
 ]
 
 [[package]]
@@ -1277,6 +1333,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "in-n-out"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1389,6 +1454,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1420,6 +1494,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
 ]
+
+[[package]]
+name = "jsonpath-rw"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "ply" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/7c/45001b1f19af8c4478489fbae4fc657b21c4c669d7a5a036a86882581d85/jsonpath-rw-1.4.0.tar.gz", hash = "sha256:05c471281c45ae113f6103d1268ec7a4831a2e96aa80de45edc89b11fac4fbec", size = 13814, upload-time = "2015-04-19T01:47:15.06Z" }
 
 [[package]]
 name = "jsonschema"
@@ -1749,6 +1834,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mlcroissant"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "etils", version = "1.13.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version < '3.11'" },
+    { name = "etils", version = "1.14.0", source = { registry = "https://pypi.org/simple" }, extra = ["epath"], marker = "python_full_version >= '3.11'" },
+    { name = "jsonpath-rw" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas" },
+    { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas-stubs", version = "3.0.3.260530", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil" },
+    { name = "rdflib" },
+    { name = "requests" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/94/67287557ad889c85d37700bed09b33f1be8b7a272a5d0dbb84f4a697e7b0/mlcroissant-1.1.0.tar.gz", hash = "sha256:fd4a5fc875fa1531fabe4c131acdf8aaf9428fd69583cc51a7a5c23262b48259", size = 111643, upload-time = "2026-04-16T13:18:44.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/f9/9d4602e4346e4d6625e67ddcfd1ebd8d7d13860025bde43c8ed8149758e5/mlcroissant-1.1.0-py2.py3-none-any.whl", hash = "sha256:46f9ab72fc193e1e3730dbbd872eb8cdf07ca16e854578c5c30c2aad2854423a", size = 155405, upload-time = "2026-04-16T13:18:42.718Z" },
 ]
 
 [[package]]
@@ -2095,8 +2206,8 @@ testing = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.1.0" },
     { name = "click" },
-    { name = "copick", specifier = ">=1.23.1" },
-    { name = "copick-shared-ui", specifier = ">=0.5.0" },
+    { name = "copick", specifier = ">=1.26.1" },
+    { name = "copick-shared-ui", specifier = ">=0.7.0" },
     { name = "fsspec" },
     { name = "hatch-vcs", marker = "extra == 'dev'", specifier = ">=0.4.0" },
     { name = "hatchling", marker = "extra == 'dev'", specifier = ">=1.25.0" },
@@ -2555,6 +2666,43 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.3.3.260113"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version > '3.10' and python_full_version < '3.11' and platform_machine != 'x86_64') or (python_full_version > '3.10' and python_full_version < '3.11' and sys_platform != 'win32')",
+    "python_full_version > '3.10' and python_full_version < '3.11' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "(python_full_version <= '3.10' and platform_machine != 'x86_64') or (python_full_version <= '3.10' and sys_platform != 'win32')",
+    "python_full_version <= '3.10' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.3.260530"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.12' and sys_platform != 'win32')",
+    "python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+    "(python_full_version == '3.11.*' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and sys_platform != 'win32')",
+    "python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
+]
+
+[[package]]
 name = "parso"
 version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2730,6 +2878,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "ply"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
 ]
 
 [[package]]
@@ -3136,6 +3293,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pyproject-api"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3472,6 +3638,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/01/392eba83c8e47b946b929d7c46e0f04b35e9671f8bb6fc36b6f7945b4de8/qtpy-2.4.3.tar.gz", hash = "sha256:db744f7832e6d3da90568ba6ccbca3ee2b3b4a890c3d6fbbc63142f6e4cdf5bb", size = 66982, upload-time = "2025-02-11T15:09:25.759Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/76/37c0ccd5ab968a6a438f9c623aeecc84c202ab2fabc6a8fd927580c15b5a/QtPy-2.4.3-py3-none-any.whl", hash = "sha256:72095afe13673e017946cc258b8d5da43314197b741ed2890e563cf384b51aa1", size = 95045, upload-time = "2025-02-11T15:09:24.162Z" },
+]
+
+[[package]]
+name = "rdflib"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "isodate", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/f5/18bb77b7af9526add0c727a3b2048959847dc5fb030913e2918bf384fec3/rdflib-7.6.0.tar.gz", hash = "sha256:6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df", size = 4943826, upload-time = "2026-02-13T07:15:55.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/c2/6604a71269e0c1bd75656d5a001432d16f2cc5b8c057140ec797155c295e/rdflib-7.6.0-py3-none-any.whl", hash = "sha256:30c0a3ebf4c0e09215f066be7246794b6492e054e782d7ac2a34c9f70a15e0dd", size = 615416, upload-time = "2026-02-13T07:15:46.487Z" },
 ]
 
 [[package]]
@@ -4412,6 +4591,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2026.2.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/d9/9fa4019d2235bd374293e1fd4153879b28b6ae1d2bae98addd352c9713f2/types_pytz-2026.2.0.20260518.tar.gz", hash = "sha256:e5d254329e9c4e91f0781b22c43a4bb2d10bb044d97b24c4b05d45567b0eae16", size = 10871, upload-time = "2026-05-18T06:02:45.789Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/89/41e80670779a223d8bc8bc83019a619988cfa5c432cedac5cec23884fbc4/types_pytz-2026.2.0.20260518-py3-none-any.whl", hash = "sha256:3a12eaa38f476bd650902a9c9bb442f03f3c7dee2be5c5848bce61bd708d205a", size = 10125, upload-time = "2026-05-18T06:02:44.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
On smaller screens (e.g. MacBook) napari-copick is essentially unusable currently. This PR (and sister-PR in copick-shared-ui) fixes size hinting to allow shrinking the widget to a more reasonable size on small screens. 